### PR TITLE
esm file extension

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -25,6 +25,5 @@ esbuild.buildSync({
   minify: isProduction,
   sourcemap: !isProduction,
   splitting: true,
-  outExtension: { ".js": ".mjs" },
   target,
 });

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "workbox"
   ],
   "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "index.d.ts",
   "typesVersions": {
     ">=4.0": {
@@ -26,7 +26,7 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/esm/index.mjs",
+      "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts"
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,1 @@
-export * from "./registerServiceWorker.js";
-export * from "./setupServiceWorker.js";
+export * from "./lib";

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,1 +1,3 @@
 export * from "./registerUpdatePrompt.js";
+export * from "./registerServiceWorker.js";
+export * from "./setupServiceWorker.js";

--- a/src/lib/registerServiceWorker.ts
+++ b/src/lib/registerServiceWorker.ts
@@ -2,8 +2,8 @@ import { Workbox } from "workbox-window";
 import {
   PermissionCallback,
   askNotificationPermission,
-} from "./notifications/browser.js";
-import { registerUpdatePrompt } from "./lib/registerUpdatePrompt.js";
+} from "../notifications/browser.js";
+import { registerUpdatePrompt } from "./registerUpdatePrompt.js";
 
 export type SetupBrowserOptions = {
   /** url to check for the serviceWorker */
@@ -55,7 +55,7 @@ export function registerServiceWorker(
         wb.addEventListener("waiting", (_event) => {
           console.debug(
             `A new service worker has installed, but it can't activate` +
-              `until all tabs running the current version have fully unloaded.`,
+            `until all tabs running the current version have fully unloaded.`,
           );
         });
       }

--- a/src/lib/setupServiceWorker.ts
+++ b/src/lib/setupServiceWorker.ts
@@ -1,17 +1,17 @@
 import { registerRoute } from "workbox-routing";
-import { WarmCacheArgs, warmCache } from "./lib/cache/recipes/warmCache.js";
-import { offlineFallback } from "./lib/cache/recipes/offlineFallback.js";
-import { pageCache } from "./lib/cache/recipes/pageCache.js";
+import { WarmCacheArgs, warmCache } from "./cache/recipes/warmCache.js";
+import { offlineFallback } from "./cache/recipes/offlineFallback.js";
+import { pageCache } from "./cache/recipes/pageCache.js";
 import {
   StaticResourcesCacheArgs,
   staticResourcesCache,
-} from "./lib/cache/recipes/staticResourcesCache.js";
-import { ImageCacheArgs, imageCache } from "./lib/cache/recipes/imageCache.js";
-import { StrategyConfig, getStrategy } from "./lib/cache/strategies.js";
+} from "./cache/recipes/staticResourcesCache.js";
+import { ImageCacheArgs, imageCache } from "./cache/recipes/imageCache.js";
+import { StrategyConfig, getStrategy } from "./cache/strategies.js";
 import {
   PushNotificationsConfig,
   pushNotifications,
-} from "./notifications/serviceWorker.js";
+} from "../notifications/serviceWorker.js";
 
 import { OfflineFallbackOptions } from "workbox-recipes";
 import { NetworkFirstOptions } from "workbox-strategies";


### PR DESCRIPTION
esbuild produces mjs files which try to import js files. This doesn't work, so switching back to js file extension.